### PR TITLE
Fix settings save types mismatch

### DIFF
--- a/lib/controllers/settings_controller.dart
+++ b/lib/controllers/settings_controller.dart
@@ -38,11 +38,10 @@ class SettingsController extends GetxController {
     mqttPassword.value = mqttPasswordController.text;
     mqttPort.value = int.tryParse(mqttPortController.text) ?? 1883;
 
-    box.write("mqtt_hostname", hostname);
-    box.write("mqtt_username", mqttUsername);
-    box.write("mqtt_password", mqttPassword);
-    box.write("mqtt_port", mqttPort);
-    box.save();
+    box.write("mqtt_hostname", hostname.string);
+    box.write("mqtt_username", mqttUsername.string);
+    box.write("mqtt_password", mqttPassword.string);
+    box.write("mqtt_port", mqttPort.toInt());
 
     hostnameController.text = hostname.value;
     mqttUsernameController.text = mqttUsername.value;


### PR DESCRIPTION
Saving settings doesn't work due to type mismatch