### PR TITLE
Fix title in web app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      title: 'Flutter Demo',
+      title: 'Open Mower App',
       theme: ThemeData(
         // This is the theme of your application.
         //


### PR DESCRIPTION
This should fix the issue where the title of the web app changes from 'open_mower_app' to 'Flutter Demo' while the page is loading.

Instead, once the page has loaded, it should now display 'Open Mower App'.

Thanks!