### PR TITLE
build_and_deploy.sh: remove deprecated web-renderer parameter

### DIFF
--- a/build_and_deploy.sh
+++ b/build_and_deploy.sh
@@ -2,7 +2,7 @@
 
 rm -rf ./build
 flutter clean
-flutter build web --web-renderer canvaskit --dart-define=FLUTTER_WEB_CANVASKIT_URL=/canvaskit/
+flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=/canvaskit/
 
 rm -rf ~/Dev/open_mower_ros/web
 


### PR DESCRIPTION
As mentioned in https://docs.flutter.dev/release/release-notes/release-notes-3.29.0 the parameter is removed in latest flutter version:
> [tool] Removes deprecated --web-renderer parameter. by @ditman in 159314

Removing it from the script.