### PR TITLE
Don't use externally hosted flutter resources

### DIFF
--- a/build_and_deploy.sh
+++ b/build_and_deploy.sh
@@ -2,7 +2,7 @@
 
 rm -rf ./build
 flutter clean
-flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=/canvaskit/
+flutter build web --no-web-resources-cdn --dart-define=FLUTTER_WEB_CANVASKIT_URL=/canvaskit/
 
 # Replace built files in the `open_mower_ros` folder, which must be present in the same parent folder
 rm -rf ../open_mower_ros/web/


### PR DESCRIPTION
Hello,

Currently the UI doesn't load on devices disconnected from the Internet due to canvaskit being loaded from gstatic.com.  It looks like there's an option in Flutter to disable content loading from CDNs and it seems to work in my testing.

Before:
<img width="1327" height="933" alt="Screenshot 2025-10-02 at 19 44 07" src="https://github.com/user-attachments/assets/c1173230-48eb-4795-94e9-e0e83ac46724" />
After:
<img width="1329" height="935" alt="Screenshot 2025-10-02 at 19 45 00" src="https://github.com/user-attachments/assets/51b1758a-9d65-4c9d-a95f-a4b47a45d399" />

There is a notable downside in that the network bandwidth to the mower is likely lower than that to gstatic.com for people who **do** have Internet access, so for most people the initial page load could take longer.  

I believe the ability to function without external resources is a benefit, but understand that I'm strongly opinionated in that regard and perhaps it's not a factor for this project (and this UI component in particular).  That said, I do recall seeing messages from people on Discord trying to set up mowers in locations with no or weak Internet access so perhaps others would benefit.

WIth the current project structure I don't see an elegant way to make this an option.  One way would be to build the UI both ways and include both UIs in the main project repo, but it's definitely not elegant.

Looking forward to your thoughts, thank you.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Web app builds now serve all web resources locally rather than via an external CDN.
  - Reduces third‑party network requests and can improve reliability in restricted or offline-prone environments.
  - Initial load size may increase due to bundled assets; no functional changes to the app experience.
  - Deployment flow and subsequent post-build steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->