### PR TITLE
Re-enable serving canvaskit locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ RUN set -eux; \
     echo "--web-renderer flag not supported; using default"; \
     RENDER_OPT=""; \
     fi; \
-    flutter build web --release $RENDER_OPT; \
-    if [ "$WEB_RENDERER" = "html" ]; then rm -rf build/web/canvaskit || true; fi; \
+    flutter build web --no-web-resources-cdn --release $RENDER_OPT; \
     find build/web -maxdepth 1 -name '*.map' -delete 2>/dev/null || true; \
     find build/web/assets -name '*.map' -delete 2>/dev/null || true
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -51,5 +51,16 @@ http {
     location ~* \.(html)$ {
       add_header Cache-Control "no-cache";
     }
+
+    # Serve WebAssembly files as application/wasm
+    location ~ \.wasm$ {
+      types {
+        application/wasm wasm;
+        default_type application/wasm;
+      }
+      add_header Cache-Control "public, max-age=3600, must-revalidate";
+      try_files $uri =404;
+    }
+
   }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -54,10 +54,7 @@ http {
 
     # Serve WebAssembly files as application/wasm
     location ~ \.wasm$ {
-      types {
-        application/wasm wasm;
-        default_type application/wasm;
-      }
+      default_type application/wasm;
       add_header Cache-Control "public, max-age=3600, must-revalidate";
       try_files $uri =404;
     }


### PR DESCRIPTION
This re-enables serving canvaskit resources locally.  I'm not sure why nginx doesn't seem to apply the correct mime type to WebAssembly by default, it seems to be present in the mimes list.  Maybe compression has something to do with it.  I didn't dig deep into it and the location block seems to work for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved web build configuration for Flutter: added CDN-related build flag and removed an HTML-specific cleanup step.
  * Enhanced WebAssembly delivery: set correct MIME type, added explicit caching headers (public, max-age), and a 404 fallback to improve loading and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->